### PR TITLE
fix: delete nodes

### DIFF
--- a/FEEDBACK.md
+++ b/FEEDBACK.md
@@ -1,7 +1,7 @@
 ## Some thoughts
 
 - [ ] it feels a bit unhandy that the inputs are on the left side of the node and the outputs are a the bottom. This kind of forces the program to grow in a starcase shape downwards towards the right, which forces scrolling in two directions instead of just up-down or left-right. In biggish sketches it would be more usable to have a dataflow that travel in one axis only.
-- [ ] for some reason to delete a node I must select it and delete it twice
+- [x] for some reason to delete a node I must select it and delete it twice
 - [x] difference between the `save` and the `save & close` button in the settings pannel not very clear, what is saved? you mean apply new settings to node? or save state in file? bit unclear? could the settings be applied just 'on change' in the dialog entry?
 - [x] when I was messing around with the codebase to add a new node type I saw the app fail silently... I thought that was a javascript feature that was not possible with typescript.
 

--- a/apps/electron-app/package.json
+++ b/apps/electron-app/package.json
@@ -63,7 +63,7 @@
 		"@microflow/ui": "workspaces:*",
 		"@microflow/utils": "workspaces:*",
 		"@tsparticles/react": "3.0.0",
-		"@xyflow/react": "12.3.1",
+		"@xyflow/react": "12.3.6",
 		"abcjs": "6.4.3",
 		"electron-log": "5.2.0",
 		"firmata": "https://github.com/xiduzo/firmata.js.git",

--- a/apps/electron-app/src/app.tsx
+++ b/apps/electron-app/src/app.tsx
@@ -11,11 +11,22 @@ import { useSignalNodesAndEdges } from './render/hooks/useSignalNodesAndEdges';
 import { useCelebrateFirstUpload, useCheckBoard } from './render/hooks/useBoard';
 import { CelebrationProvider } from './render/providers/CelebrationProvider';
 import { NewNodeCommandDialog } from './render/providers/NewNodeProvider';
+import { useEffect } from 'react';
 
 export function App() {
 	const [mqttConfig] = useLocalStorage<MqttConfig>('mqtt-config', {
 		uniqueId: uniqueNamesGenerator({ dictionaries: [adjectives, animals] }),
 	});
+
+	useEffect(() => {
+		const log = (event: KeyboardEvent) => console.log(event);
+
+		window.addEventListener('keydown', log);
+
+		return () => {
+			window.removeEventListener('keydown', log);
+		};
+	}, []);
 
 	return (
 		<>

--- a/apps/electron-app/src/app.tsx
+++ b/apps/electron-app/src/app.tsx
@@ -11,22 +11,11 @@ import { useSignalNodesAndEdges } from './render/hooks/useSignalNodesAndEdges';
 import { useCelebrateFirstUpload, useCheckBoard } from './render/hooks/useBoard';
 import { CelebrationProvider } from './render/providers/CelebrationProvider';
 import { NewNodeCommandDialog } from './render/providers/NewNodeProvider';
-import { useEffect } from 'react';
 
 export function App() {
 	const [mqttConfig] = useLocalStorage<MqttConfig>('mqtt-config', {
 		uniqueId: uniqueNamesGenerator({ dictionaries: [adjectives, animals] }),
 	});
-
-	useEffect(() => {
-		const log = (event: KeyboardEvent) => console.log(event);
-
-		window.addEventListener('keydown', log);
-
-		return () => {
-			window.removeEventListener('keydown', log);
-		};
-	}, []);
 
 	return (
 		<>

--- a/apps/electron-app/src/index.css
+++ b/apps/electron-app/src/index.css
@@ -11,7 +11,7 @@ body {
 
 /* Nodes */
 .react-flow__minimap .react-flow__minimap-node {
-	@apply fill-muted transition-all;
+	@apply fill-muted transition-colors;
 }
 .react-flow__minimap .react-flow__minimap-node.selected {
 	@apply fill-blue-500;
@@ -19,7 +19,7 @@ body {
 
 /* Edges */
 .react-flow__edges .react-flow__edge-path {
-	@apply stroke-[4] stroke-neutral-600 transition-all;
+	@apply stroke-[4] stroke-neutral-600 transition-colors;
 }
 
 .react-flow__edges .react-flow__edge.selected .react-flow__edge-path,

--- a/apps/electron-app/src/render/components/react-flow/ReactFlowCanvas.tsx
+++ b/apps/electron-app/src/render/components/react-flow/ReactFlowCanvas.tsx
@@ -27,7 +27,6 @@ export function ReactFlowCanvas() {
 			colorMode="dark"
 			minZoom={0.2}
 			maxZoom={2}
-			disableKeyboardA11y={true}
 		>
 			<Controls />
 			<MiniMap nodeBorderRadius={12} />

--- a/apps/electron-app/src/render/components/react-flow/ReactFlowCanvas.tsx
+++ b/apps/electron-app/src/render/components/react-flow/ReactFlowCanvas.tsx
@@ -1,9 +1,9 @@
-import { useAutoAnimate } from '@ui/index';
 import { Background, Controls, MiniMap, Panel, ReactFlow } from '@xyflow/react';
 import { useShallow } from 'zustand/react/shallow';
 import { NODE_TYPES } from '../../../common/nodes';
 import { AppState, useReactFlowStore } from '../../stores/react-flow';
 import { SerialConnectionStatusPanel } from './panels/SerialConnectionStatusPanel';
+import { SettingsPanel } from './panels/SettingsPanel';
 
 const selector = (state: AppState) => ({
 	nodes: state.nodes,
@@ -15,9 +15,6 @@ const selector = (state: AppState) => ({
 
 export function ReactFlowCanvas() {
 	const store = useReactFlowStore(useShallow(selector));
-	const [animationRef] = useAutoAnimate({
-		duration: 100,
-	});
 
 	return (
 		<ReactFlow
@@ -50,9 +47,7 @@ export function ReactFlowCanvas() {
 			</Panel>
 
 			<Panel position="top-right">
-				<section id="settings-panels" className="flex flex-col space-y-2" ref={animationRef}>
-					{/* Filled by settings */}
-				</section>
+				<SettingsPanel />
 			</Panel>
 		</ReactFlow>
 	);

--- a/apps/electron-app/src/render/components/react-flow/nodes/Node.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/Node.tsx
@@ -96,7 +96,7 @@ function NodeHeader(props: { error?: string; selected?: boolean }) {
 						</TooltipProvider>
 					)}
 				</div>
-				<span className="text-muted-foreground/40 text-xs font-extralight">{id}</span>
+				<span className="text-muted-foreground text-xs font-extralight">{id}</span>
 			</div>
 			<NodeSettingsButton />
 		</header>
@@ -167,7 +167,6 @@ function NodeSettingsPane<T extends Record<string, unknown>>(
 	const updateNode = useUpdateNode(id);
 
 	const ref = useRef<HTMLDivElement>(null);
-	const autoUpdate = useRef<NodeJS.Timeout | null>(null);
 	const settings = useRef(data);
 	const handlesToDelete = useRef<string[]>([]);
 
@@ -192,10 +191,7 @@ function NodeSettingsPane<T extends Record<string, unknown>>(
 		pane.on('change', event => {
 			if (!event.last) return;
 
-			autoUpdate.current && clearTimeout(autoUpdate.current);
-			autoUpdate.current = setTimeout(() => {
-				saveSettings();
-			}, 1_000);
+			saveSettings();
 		});
 
 		pane.registerPlugin(TweakpaneEssentialPlugin);

--- a/apps/electron-app/src/render/components/react-flow/panels/SettingsPanel.tsx
+++ b/apps/electron-app/src/render/components/react-flow/panels/SettingsPanel.tsx
@@ -1,0 +1,13 @@
+import { useAutoAnimate } from '@ui/index';
+
+export function SettingsPanel() {
+	const [animationRef] = useAutoAnimate({
+		duration: 100,
+	});
+
+	return (
+		<section id="settings-panels" className="flex flex-col space-y-2" ref={animationRef}>
+			{/* Filled by settings */}
+		</section>
+	);
+}

--- a/apps/electron-app/src/render/stores/new-node.ts
+++ b/apps/electron-app/src/render/stores/new-node.ts
@@ -15,5 +15,7 @@ export const useNewNodeStore = create<NewNodeStore>((set, get) => ({
 	nodeToAdd: null as string | null,
 	setNodeToAdd: (nodeId: string | null) => {
 		set({ nodeToAdd: nodeId });
+
+		if (nodeId) set({ open: false });
 	},
 }));

--- a/apps/electron-app/src/render/stores/react-flow.ts
+++ b/apps/electron-app/src/render/stores/react-flow.ts
@@ -14,7 +14,7 @@ import { LinkedList } from '../../common/LinkedList';
 import { INTRODUCTION_EDGES, INTRODUCTION_NODES } from './introduction';
 import { useShallow } from 'zustand/react/shallow';
 
-const HISTORY_DEBOUNCE_TIME_IN_MS = 1000;
+const HISTORY_DEBOUNCE_TIME_IN_MS = 100;
 
 export type AppState<NodeData extends Record<string, unknown> = {}> = {
 	nodes: Node<NodeData>[];
@@ -25,6 +25,7 @@ export type AppState<NodeData extends Record<string, unknown> = {}> = {
 	setNodes: (nodes: Node<NodeData>[]) => void;
 	setEdges: (edges: Edge[]) => void;
 	deleteEdges: (nodeId: string, handles?: string[]) => void;
+	deleteSelectedNodes: () => void;
 	history: LinkedList<{ nodes: Node[]; edges: Edge[] }>;
 	undo: () => void;
 	redo: () => void;
@@ -59,9 +60,7 @@ export const useReactFlowStore = create<AppState>((set, get) => {
 	const initialEdges = hasSeenIntroduction ? localEdges : INTRODUCTION_EDGES;
 
 	let historyUpdateDebounce: NodeJS.Timeout | undefined;
-	function updateHistory(update: Partial<Pick<AppState, 'nodes' | 'edges'>>) {
-		set(update);
-
+	function updateHistory() {
 		historyUpdateDebounce && clearTimeout(historyUpdateDebounce);
 		historyUpdateDebounce = setTimeout(() => {
 			const { nodes, edges, history } = get();
@@ -74,30 +73,28 @@ export const useReactFlowStore = create<AppState>((set, get) => {
 		edges: initialEdges,
 		history: new LinkedList({ nodes: initialNodes, edges: initialEdges }),
 		onNodesChange: changes => {
-			console.log(...changes);
-			updateHistory({ nodes: applyNodeChanges(changes, get().nodes) });
-
-			changes.forEach(change => {
-				if (change.type === 'remove') {
-					const { edges } = get();
-					const newEdges = edges.filter(
-						edge => edge.source !== change.id && edge.target !== change.id,
-					);
-					set({ edges: newEdges });
-				}
+			set({
+				nodes: applyNodeChanges(changes, get().nodes),
 			});
+
+			updateHistory();
 		},
 		onEdgesChange: changes => {
-			updateHistory({ edges: applyEdgeChanges(changes, get().edges) });
+			set({
+				edges: applyEdgeChanges(changes, get().edges),
+			});
+			updateHistory();
 		},
 		onConnect: connection => {
-			updateHistory({ edges: addEdge(connection, get().edges) });
+			set({
+				edges: addEdge(connection, get().edges),
+			});
 		},
 		setNodes: nodes => {
-			updateHistory({ nodes });
+			set({ nodes });
 		},
 		setEdges: edges => {
-			updateHistory({ edges });
+			set({ edges });
 		},
 		deleteEdges: (nodeId, handles = []) => {
 			if (!handles.length) return;
@@ -113,7 +110,12 @@ export const useReactFlowStore = create<AppState>((set, get) => {
 
 				return false;
 			});
-			updateHistory({ edges });
+
+			set({ edges });
+		},
+		deleteSelectedNodes: () => {
+			const nodes = get().nodes.filter(node => !node.selected);
+			set({ nodes });
 		},
 		undo: () => {
 			const history = get().history;
@@ -143,12 +145,8 @@ export function useNodeAndEdgeCount() {
 	);
 }
 
-export function useTempNode() {
-	return useReactFlowStore(
-		useShallow(state => ({
-			onNodesChange: state.onNodesChange,
-		})),
-	);
+export function useNodesChange() {
+	return useReactFlowStore(useShallow(state => state.onNodesChange));
 }
 
 export function useDeleteEdges() {
@@ -157,4 +155,8 @@ export function useDeleteEdges() {
 
 export function useEdges() {
 	return useReactFlowStore(useShallow(state => state.edges));
+}
+
+export function useDeleteSelectedNodes() {
+	return useReactFlowStore(useShallow(state => state.deleteSelectedNodes));
 }

--- a/apps/nextjs-app/app/docs/contributing/nodes/page.md
+++ b/apps/nextjs-app/app/docs/contributing/nodes/page.md
@@ -24,15 +24,13 @@ export type MyNodeData = {
 	emotion: EmotionType;
 	joy: number;
 };
-
-type MyNodeOptions = BaseComponentOptions & MyNodeData;
 ```
 
 Add a constructor to your type that takes the attributes and passes them to the superclass. Like this:
 
 ```
-	constructor(private readonly options: MyNodeOptions) {
-		super(options, 0);
+	constructor(private readonly data: BaseComponentData & MyNodeData) {
+		super(data, 0);
 	}
 ```
 
@@ -93,7 +91,7 @@ function Settings() {
 - And your panel setting defaults.
 
 ```
-type Props = BaseNode<MyNodeData, MyNodeValueType>;
+type Props = BaseNode<MyNodeData>;
 export const DEFAULT_MYNODE_DATA: Props['data'] = {
 	label: 'MyNode',
 	emotion: 'happy',
@@ -124,10 +122,10 @@ DEFAULT_MYNODE_DATA.set('MyNode', DEFAULT_MYNODE_DATA);
 - Add some JSX in `apps/electron-app/src/render/NewNodeProvider.tsx` so that it appears in the search menu.
 
 ```
-					<CommandItem onSelect={selectNode('MyNode')}>
-					MyNode
-						<CommandShortcut>
-							<Badge variant="outline">Custom</Badge>
-						</CommandShortcut>
-					</CommandItem>
+<CommandItem onSelect={selectNode('MyNode')}>
+MyNode
+	<CommandShortcut>
+		<Badge variant="outline">Custom</Badge>
+	</CommandShortcut>
+</CommandItem>
 ```

--- a/apps/nextjs-app/app/docs/contributing/nodes/page.md
+++ b/apps/nextjs-app/app/docs/contributing/nodes/page.md
@@ -4,12 +4,11 @@ title: How to add your own node
 
 Adding your own node requires a bit of boilerplate and manual work at the moment.
 
-
 ## Step 1: creating your own component type
 
 Let's say you want to create your own node type called `MyNode`. First you need to create a file with it's own class in `packages/components/src/YourNode.ts` your type must extend the BaseComponent class. Here's an example declaration:
 
-```
+```ts
 export type MyNodeValueType = number;
 
 export class MyNode extends BaseComponent<MyNodeValueType> {}
@@ -17,7 +16,7 @@ export class MyNode extends BaseComponent<MyNodeValueType> {}
 
 Let's now say that your node type will have a configuration panel where you can change some attributes, for now let's say the attributes are a drop-down that let's you choose between `happy` and `sad`, and a numeric value we call `joy`. To be able to contain the values of these attributes you will need a data type associated to your node.
 
-```
+```ts
 export type EmotionType = 'happy' | 'sad';
 
 export type MyNodeData = {
@@ -28,23 +27,22 @@ export type MyNodeData = {
 
 Add a constructor to your type that takes the attributes and passes them to the superclass. Like this:
 
-```
-	constructor(private readonly data: BaseComponentData & MyNodeData) {
-		super(data, 0);
-	}
+```ts
+constructor(private readonly data: BaseComponentData & MyNodeData) {
+	super(data, 0);
+}
 ```
 
 ## Step 2: expose your new type in the components packages and refresh build
 
 - Include your newly created component in the `index.ts` file in `packages/components`. This will make your new components available in the `@microflow/components` package, so that they can be used later in the electron app.
-- run `yarn build` in the `microflow/packages/components` directory, you need to do this before you run yarn at the `app` level directories
 
 ## Step 3: create a react wrapper in the electron app
 
 - Create a reactflow wrapper for your node type in `apps/electron-app/src/common/render/componenets/react-flow/nodes/YourNode.tsx`
 - Implement here your JSX
 
-```
+```tsx
 export function MyNode(props: Props) {
 	return (
 		<NodeContainer {...props}>
@@ -57,9 +55,22 @@ export function MyNode(props: Props) {
 }
 ```
 
-- Your config panel (@TODO link to documentation)
+- Show how much `joy` you are in right now
 
+```tsx
+function Value() {
+    const value = useNodeValue<MyNodeValueType>(0) // Acces the nodes' internal value
+    const data = useNodeData<MyNodeData>() // Access the node data
+
+    return {
+        <div>{value} / {data.joy}</div>
+    }
+}
 ```
+
+- Give the user freedom to configure the node
+
+```tsx
 function Settings() {
 	const { pane, settings } = useNodeSettingsPane<MyNodeData>();
 
@@ -88,9 +99,9 @@ function Settings() {
 }
 ```
 
-- And your panel setting defaults.
+- And your panel data defaults.
 
-```
+```ts
 type Props = BaseNode<MyNodeData>;
 export const DEFAULT_MYNODE_DATA: Props['data'] = {
 	label: 'MyNode',
@@ -101,31 +112,34 @@ export const DEFAULT_MYNODE_DATA: Props['data'] = {
 
 - Add a reference in `apps/electron-app/src/common/nodes.ts`
 
-```
+```ts
 import { DEFAULT_MYNODE_DATA, MyNode } from '../render/components/react-flow/nodes/MyNode';
 ```
 
 Add the correct entry to the `NODE_TYPES` list:
-```
+
+```ts
 export const NODE_TYPES = {
   ...
   MyNode: MyNode,
   ...
-};```
-
-And last but not least i that same file, add an entry that specifies the default attribute values for the node:
-
+};
 ```
+
+And last but not least in that same file, add an entry that specifies the default attribute values for the node:
+
+```ts
 DEFAULT_MYNODE_DATA.set('MyNode', DEFAULT_MYNODE_DATA);
 ```
 
 - Add some JSX in `apps/electron-app/src/render/NewNodeProvider.tsx` so that it appears in the search menu.
 
-```
+```tsx
 <CommandItem onSelect={selectNode('MyNode')}>
-MyNode
-	<CommandShortcut>
-		<Badge variant="outline">Custom</Badge>
-	</CommandShortcut>
+    MyNode
+    <CommandShortcut className="space-x-1">
+    	<Badge variant="outline">custom</Badge>
+        {/* <Badge variant="outline">...</Badge> */}
+    </CommandShortcut>
 </CommandItem>
 ```

--- a/apps/nextjs-app/lib/navigation.ts
+++ b/apps/nextjs-app/lib/navigation.ts
@@ -101,6 +101,9 @@ export const navigation = [
 	},
 	{
 		title: 'Community',
-		links: [{ title: 'How to contribute', href: '/docs/contributing/how-to' }],
+		links: [
+			{ title: 'How to contribute', href: '/docs/contributing/how-to' },
+			{ title: 'Add your own node', href: '/docs/contributing/nodes' },
+		],
 	},
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5340,23 +5340,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xyflow/react@npm:12.3.1":
-  version: 12.3.1
-  resolution: "@xyflow/react@npm:12.3.1"
+"@xyflow/react@npm:12.3.6":
+  version: 12.3.6
+  resolution: "@xyflow/react@npm:12.3.6"
   dependencies:
-    "@xyflow/system": 0.0.43
+    "@xyflow/system": 0.0.47
     classcat: ^5.0.3
     zustand: ^4.4.0
   peerDependencies:
     react: ">=17"
     react-dom: ">=17"
-  checksum: 01f5369c64db0f2c11c27339b5a79d83a2246f0812b466a23b905a96297c1578a48e044a3d5a37cad506ba752eaf9d9eee93dcc6bbff93e9bbd0b282f133cea4
+  checksum: c8f86c900502d4b4cb74cdb525a2b25730d54ca63792154127aaf7e075587a0f016121396e7c6185f4872af5585c0e6e515a2ce506e3b70822eb2a0b48c7b266
   languageName: node
   linkType: hard
 
-"@xyflow/system@npm:0.0.43":
-  version: 0.0.43
-  resolution: "@xyflow/system@npm:0.0.43"
+"@xyflow/system@npm:0.0.47":
+  version: 0.0.47
+  resolution: "@xyflow/system@npm:0.0.47"
   dependencies:
     "@types/d3-drag": ^3.0.7
     "@types/d3-selection": ^3.0.10
@@ -5365,7 +5365,7 @@ __metadata:
     d3-drag: ^3.0.0
     d3-selection: ^3.0.0
     d3-zoom: ^3.0.0
-  checksum: 25effd99488ad9f22b7baef2306bc59ddb1906c51655edce3b1b4bb2fdc034f404009ecb022ef1eaa1f40191ba43da11416de93786d5ec8b83d2c34b945526f9
+  checksum: 2f1788bce46610055de857f8743e794394dcc53ffd6e0943bf6e7718fb6334ca29dffd0e57e7c8de0b1eaaa3e63e082cbdebc3caefaf506a4e8f2971a40f6d88
   languageName: node
   linkType: hard
 
@@ -11057,7 +11057,7 @@ __metadata:
     "@types/npmcli__arborist": 5.6.11
     "@types/react": 18.3.11
     "@types/react-dom": 18.3.0
-    "@xyflow/react": 12.3.1
+    "@xyflow/react": 12.3.6
     abcjs: 6.4.3
     autoprefixer: 10.4.20
     dotenv: 16.4.5


### PR DESCRIPTION
When adding nodes via the menu using the hotkey `cmd/ctrl + k`, `xyflow` was getting into a state which did not recognise the first `Backspace` keypress anymore. Issue is [documented and reported](https://github.com/xyflow/xyflow/issues/4761).

This PR will overwrite the default behaviour untill `xyflow` has resolved it on their end