### PR TITLE
chore: make use of `apple-actions/import-codesign-certs`

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -57,9 +57,6 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
-      - name: Remove out directory
-        run: rm -rf ./apps/electron-app/out
-
       # https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions
       - name: Make application
         run: yarn make

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -64,4 +64,5 @@ jobs:
           APPLE_ID: ${{secrets.APPLE_ID}}
           APPLE_ID_PASSWORD: ${{secrets.APPLE_ID_PASSWORD}}
           APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
+          APPLE_DEVELOPER_ID_APPLICATION: ${{secrets.APPLE_DEVELOPER_ID_APPLICATION}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,32 +21,12 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - name: Install the Apple certificate
+      - name: Import Code-Signing Certificates (MacOS)
         if: runner.os == 'macOS'
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-          # import certificate
-          echo -n "$MACOS_CERTIFICATE" | base64 --decode -o $CERTIFICATE_PATH
-
-          # create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$MACOS_CERTIFICATE_PWD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-      - name: Run security find-identity -v
-        if: runner.os == 'macOS'
-        run: security find-identity -v
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATE_OSX_P12 }}
+          p12-password: ${{ secrets.CERTIFICATE_OSX_P12_PASSWORD }}
 
       - uses: actions/checkout@v4
 
@@ -69,21 +49,17 @@ jobs:
       - name: Build packages
         run: yarn build
 
-      - uses: actions/setup-python@v5
-        with:
-          # https://stackoverflow.com/a/78870850/4655177
-          # Required for `distutils` module
-          python-version: '3.10'
-
-      - name: Install provisioning profile
+      # https://stackoverflow.com/a/78870850/4655177
+      - name: Install Python setup tools (MacOS)
         if: runner.os == 'macOS'
-        env:
-          MACOS_PROVISIONING_PROFILE: ${{ secrets.MACOS_PROVISIONING_PROFILE }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install Python setup tools (MacOS)
+        if: runner.os == 'macOS'
         run: |
-          # Decode and install provisioning profile
-          PROFILE_PATH=apps/electron-app/microflow.provisionprofile
-          echo -n "$MACOS_PROVISIONING_PROFILE" | base64 --decode > $PROFILE_PATH
-          echo "Provisioning profile installed at $PROFILE_PATH"
+          pip install setuptools
 
       # https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions
       - name: Make application
@@ -93,8 +69,4 @@ jobs:
           APPLE_ID: ${{ vars.APPLE_ID }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-
-      - name: Clean up keychain and provisioning profile
-        if: runner.os == 'macOS'
-        run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -56,17 +56,15 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
-      - name: Install Python setup tools (MacOS)
-        if: runner.os == 'macOS'
-        run: |
-          pip install setuptools
+
+      - name: Remove out directory
+        run: rm -rf ./apps/electron-app/out
 
       # https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions
       - name: Make application
         run: yarn make
         env:
-          APPLE_IDENTITY: ${{ vars.APPLE_IDENTITY }}
-          APPLE_ID: ${{ vars.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_ID: ${{secrets.APPLE_ID}}
+          APPLE_ID_PASSWORD: ${{secrets.APPLE_ID_PASSWORD}}
+          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,28 +15,12 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - name: Install the Apple certificate
+      - name: Import Code-Signing Certificates (MacOS)
         if: runner.os == 'macOS'
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-          # import certificate
-          echo -n "$MACOS_CERTIFICATE" | base64 --decode -o $CERTIFICATE_PATH
-
-          # create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$MACOS_CERTIFICATE_PWD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATE_OSX_P12 }}
+          p12-password: ${{ secrets.CERTIFICATE_OSX_P12_PASSWORD }}
 
       - uses: actions/checkout@v4
 
@@ -59,32 +43,29 @@ jobs:
       - name: Build packages
         run: yarn build
 
-      - uses: actions/setup-python@v5
+      # https://stackoverflow.com/a/78870850/4655177
+      - name: Install Python setup tools (MacOS)
+        if: runner.os == 'macOS'
+        uses: actions/setup-python@v5
         with:
-          # https://stackoverflow.com/a/78870850/4655177
-          # Required for `distutils` module
           python-version: '3.10'
+          cache: 'pip'
 
       - name: Publish application
         run: yarn publish
         env:
+          APPLE_ID: ${{secrets.APPLE_ID}}
+          APPLE_ID_PASSWORD: ${{secrets.APPLE_ID_PASSWORD}}
+          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
+          APPLE_DEVELOPER_ID_APPLICATION: ${{secrets.APPLE_DEVELOPER_ID_APPLICATION}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_IDENTITY: ${{ vars.APPLE_IDENTITY }}
-          APPLE_ID: ${{ vars.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
       - name: Publish application
         if: runner.os == 'macOS'
         run: yarn publish:intel
         env:
+          APPLE_ID: ${{secrets.APPLE_ID}}
+          APPLE_ID_PASSWORD: ${{secrets.APPLE_ID_PASSWORD}}
+          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
+          APPLE_DEVELOPER_ID_APPLICATION: ${{secrets.APPLE_DEVELOPER_ID_APPLICATION}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_IDENTITY: ${{ vars.APPLE_IDENTITY }}
-          APPLE_ID: ${{ vars.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-
-      - name: Clean up keychain and provisioning profile
-        if: runner.os == 'macOS'
-        run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db

--- a/apps/electron-app/.env.example
+++ b/apps/electron-app/.env.example
@@ -1,9 +1,6 @@
 # Apple signing keys
 # see https://www.electronforge.io/guides/code-signing/code-signing-macos
-APPLE_IDENTITY='Apple Distribution: XXXXXXXX (XXXXXXXX)'
+# APPLE_IDENTITY='Developer ID Application: Adrianus Sebastiaan Boer (J7NFJN3DG9)'
 APPLE_ID='your@email.domain'
-APPLE_PASSWORD='xxxx-xxxx-xxxx-xxxx'
+APPLE_ID_PASSWORD='xxxx-xxxx-xxxx-xxxx' # app specific password via https://account.apple.com/account/manage
 APPLE_TEAM_ID='XXXXXXXXXX'
-APPLE_API_KEY='path/to/AuthKey_XXXXXXXXXX.p8'
-APPLE_API_KEY_ID='XXXXXXXX'
-APPLE_API_ISSUER='XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'

--- a/apps/electron-app/bundler.js
+++ b/apps/electron-app/bundler.js
@@ -101,7 +101,9 @@ const bundle = async (source, destination) => {
 
 		index++;
 		// Update progress bar on the same line
-		process.stdout.write(`\r${createProgressBar(index, prodDeps.length)}\x1b[K`);
+		if (index % 100 === 0) {
+			process.stdout.write(`\r${createProgressBar(index, prodDeps.length)}\x1b[K`);
+		}
 
 		// if (dest.includes('@serialport/bindings-cpp')) {
 		// 	// Check if folder exists

--- a/apps/electron-app/forge.config.js
+++ b/apps/electron-app/forge.config.js
@@ -38,7 +38,7 @@ module.exports = {
 				? {
 						tool: 'notarytool',
 						appleId: process.env.APPLE_ID,
-						appleIdPassword: process.env.APPLE_PASSWORD,
+						appleIdPassword: process.env.APPLE_ID_PASSWORD,
 						teamId: process.env.APPLE_TEAM_ID,
 					}
 				: undefined,
@@ -53,6 +53,7 @@ module.exports = {
 		disablePreGypCopy: true,
 	},
 
+	// https://www.electronforge.io/config/makers
 	makers: [
 		{ name: '@electron-forge/maker-squirrel' }, // Windows
 		{

--- a/apps/electron-app/forge.config.js
+++ b/apps/electron-app/forge.config.js
@@ -10,8 +10,6 @@ const packageVersion = packageJson.version;
 // Extract major.minor version without patch
 const shortVersion = packageVersion.split('.').slice(0, 2).join('.');
 
-const executableName = 'microflow-studio';
-
 /** @type {import('@electron-forge/shared-types').ForgeConfig} */
 module.exports = {
 	packagerConfig: {
@@ -33,7 +31,7 @@ module.exports = {
 		osxSign:
 			isCI || true
 				? {
-						// identity: process.env.APPLE_IDENTITY,
+						identity: process.env.APPLE_DEVELOPER_ID_APPLICATION,
 					}
 				: undefined,
 		osxNotarize:
@@ -85,7 +83,7 @@ module.exports = {
 			},
 		},
 	],
-	buildIdentifier: 'microflow-studio',
+	// buildIdentifier: 'microflow-studio',
 	plugins: [
 		{
 			name: '@electron-forge/plugin-vite',

--- a/apps/electron-app/forge.config.js
+++ b/apps/electron-app/forge.config.js
@@ -19,7 +19,7 @@ module.exports = {
 		appVersion: `${packageVersion}`,
 		buildVersion: `${shortVersion}.${process.env.GITHUB_RUN_ID || '0'}`,
 		// name: 'microflow-studio', // Should not have spaces or special characters (else MacOS can not build because of folder name)
-		executableName: 'Microflow studio',
+		// executableName: 'Microflow-studio', // Should not have spaces or special characters (else MacOS can not build because of folder name)
 		icon: path.resolve(__dirname, 'assets', 'icon'),
 		prune: false, // required for monorepo
 		protocols: [

--- a/apps/electron-app/forge.config.js
+++ b/apps/electron-app/forge.config.js
@@ -30,7 +30,7 @@ module.exports = {
 		osxSign:
 			isCI || true
 				? {
-						identity: process.env.APPLE_IDENTITY,
+						// identity: process.env.APPLE_IDENTITY,
 					}
 				: undefined,
 		osxNotarize:

--- a/apps/electron-app/forge.config.js
+++ b/apps/electron-app/forge.config.js
@@ -10,6 +10,8 @@ const packageVersion = packageJson.version;
 // Extract major.minor version without patch
 const shortVersion = packageVersion.split('.').slice(0, 2).join('.');
 
+const executableName = 'Microflow-studio';
+
 /** @type {import('@electron-forge/shared-types').ForgeConfig} */
 module.exports = {
 	packagerConfig: {
@@ -19,7 +21,7 @@ module.exports = {
 		appVersion: `${packageVersion}`,
 		buildVersion: `${shortVersion}.${process.env.GITHUB_RUN_ID || '0'}`,
 		// name: 'microflow-studio', // Should not have spaces or special characters (else MacOS can not build because of folder name)
-		// executableName: 'Microflow-studio', // Should not have spaces or special characters (else MacOS can not build because of folder name)
+		executableName, // Should not have spaces or special characters (else MacOS can not build because of folder name)
 		icon: path.resolve(__dirname, 'assets', 'icon'),
 		prune: false, // required for monorepo
 		protocols: [
@@ -63,7 +65,7 @@ module.exports = {
 		{
 			name: '@electron-forge/maker-deb',
 			config: {
-				bin: 'Microflow studio',
+				bin: executableName,
 				mimeType: ['x-scheme-handler/mfs', 'x-scheme-handler/microflow-studio'],
 				options: {
 					maintainer: 'Sander Boer <mail@sanderboer.nl>',
@@ -74,14 +76,12 @@ module.exports = {
 		{
 			name: '@electron-forge/maker-rpm',
 			config: {
-				bin: 'Microflow studio',
+				bin: executableName,
 				mimeType: ['x-scheme-handler/mfs', 'x-scheme-handler/microflow-studio'],
 			},
 		},
 	],
-
 	buildIdentifier: 'microflow-studio',
-
 	plugins: [
 		{
 			name: '@electron-forge/plugin-vite',

--- a/apps/electron-app/forge.config.js
+++ b/apps/electron-app/forge.config.js
@@ -10,7 +10,7 @@ const packageVersion = packageJson.version;
 // Extract major.minor version without patch
 const shortVersion = packageVersion.split('.').slice(0, 2).join('.');
 
-const executableName = 'Microflow-studio';
+const executableName = 'microflow-studio';
 
 /** @type {import('@electron-forge/shared-types').ForgeConfig} */
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
 		appCopyright: `Copyright © ${new Date().getFullYear()} Xiduzo`,
 		appVersion: `${packageVersion}`,
 		buildVersion: `${shortVersion}.${process.env.GITHUB_RUN_ID || '0'}`,
-		// name: 'microflow-studio', // Should not have spaces or special characters (else MacOS can not build because of folder name)
+		name: executableName, // Should not have spaces or special characters (else MacOS can not build because of folder name)
 		executableName, // Should not have spaces or special characters (else MacOS can not build because of folder name)
 		icon: path.resolve(__dirname, 'assets', 'icon'),
 		prune: false, // required for monorepo

--- a/apps/electron-app/forge.config.js
+++ b/apps/electron-app/forge.config.js
@@ -1,6 +1,7 @@
 const { bundle } = require('./bundler');
 const path = require('path');
 require('dotenv').config();
+const fs = require('fs/promises');
 const packageJson = require('./package.json');
 
 const isCI = !!process.env.GITHUB_ACTIONS;
@@ -17,7 +18,7 @@ module.exports = {
 		appCopyright: `Copyright © ${new Date().getFullYear()} Xiduzo`,
 		appVersion: `${packageVersion}`,
 		buildVersion: `${shortVersion}.${process.env.GITHUB_RUN_ID || '0'}`,
-		name: 'Microflow studio',
+		// name: 'microflow-studio', // Should not have spaces or special characters (else MacOS can not build because of folder name)
 		executableName: 'Microflow studio',
 		icon: path.resolve(__dirname, 'assets', 'icon'),
 		prune: false, // required for monorepo
@@ -44,9 +45,7 @@ module.exports = {
 				: undefined,
 	},
 	hooks: {
-		packageAfterCopy: async (_forgeConfig, buildPath) => {
-			await bundle(__dirname, buildPath);
-		},
+		packageAfterCopy: (_forgeConfig, buildPath) => bundle(__dirname, buildPath),
 	},
 
 	rebuildConfig: {

--- a/apps/electron-app/forge.config.js
+++ b/apps/electron-app/forge.config.js
@@ -20,8 +20,8 @@ module.exports = {
 		appCopyright: `Copyright © ${new Date().getFullYear()} Xiduzo`,
 		appVersion: `${packageVersion}`,
 		buildVersion: `${shortVersion}.${process.env.GITHUB_RUN_ID || '0'}`,
-		name: executableName, // Should not have spaces or special characters (else MacOS can not build because of folder name)
-		executableName, // Should not have spaces or special characters (else MacOS can not build because of folder name)
+		name: 'Microflow studio',
+		executableName: 'Microflow studio',
 		icon: path.resolve(__dirname, 'assets', 'icon'),
 		prune: false, // required for monorepo
 		protocols: [
@@ -59,13 +59,17 @@ module.exports = {
 		{ name: '@electron-forge/maker-squirrel' }, // Windows
 		{
 			name: '@electron-forge/maker-dmg',
-			config: { format: 'ULFO' },
+			config: {
+				format: 'ULFO',
+				name: 'microflow-studio',
+				executableName: 'microflow-studio',
+			},
 		},
 		{ name: '@electron-forge/maker-zip', platforms: ['darwin'] },
 		{
 			name: '@electron-forge/maker-deb',
 			config: {
-				bin: executableName,
+				bin: 'Microflow studio',
 				mimeType: ['x-scheme-handler/mfs', 'x-scheme-handler/microflow-studio'],
 				options: {
 					maintainer: 'Sander Boer <mail@sanderboer.nl>',
@@ -76,7 +80,7 @@ module.exports = {
 		{
 			name: '@electron-forge/maker-rpm',
 			config: {
-				bin: executableName,
+				bin: 'Microflow studio',
 				mimeType: ['x-scheme-handler/mfs', 'x-scheme-handler/microflow-studio'],
 			},
 		},

--- a/apps/electron-app/index.html
+++ b/apps/electron-app/index.html
@@ -11,7 +11,7 @@
 				default-src 'self';
 				script-src 'self' 'unsafe-inline' blob:;
 				style-src 'self' 'unsafe-inline';
-				connect-src 'self' https://*.trycloudflare.com wss: ws:;
+				connect-src 'self' https://*.trycloudflare.com wss: ws: http: https:;
 				img-src 'self' data:;
 			"
 		/>

--- a/apps/electron-app/src/app.tsx
+++ b/apps/electron-app/src/app.tsx
@@ -15,6 +15,7 @@ import { useAppStore } from './render/stores/app';
 import { MqttSettingsForm } from './render/components/forms/MqttSettingsForm';
 import { AdvancedSettingsForm } from './render/components/forms/AdvancedSettingsForm';
 import { UserSettingsForm } from './render/components/forms/UserSettingsForm';
+import logger from 'electron-log/renderer';
 
 export function App() {
 	return (
@@ -74,21 +75,21 @@ function Figma() {
 
 	useEffect(() => {
 		return subscribe(`microflow/v1/${uniqueId}/plugin/variables`, (topic, message) => {
-			console.log('[Figma] <<<< variables', topic, message.toString());
+			logger.log('[Figma] <<<< variables', topic, message.toString());
 			updateVariableTypes(JSON.parse(message.toString()) as Record<string, FigmaVariable>);
 		});
 	}, [subscribe, uniqueId, updateVariableTypes]);
 
 	useEffect(() => {
 		return subscribe(`microflow/v1/${uniqueId}/plugin/variable/+`, (topic, message) => {
-			console.log('[Figma] <<<< variable', topic, message.toString(), topic.split('/')[5]);
+			logger.log('[Figma] <<<< variable', topic, message.toString(), topic.split('/')[5]);
 			updateVariableValue(topic.split('/')[5], JSON.parse(message.toString()));
 		});
 	}, [subscribe, uniqueId, updateVariableValue]);
 
 	useEffect(() => {
 		return subscribe(`microflow/v1/${uniqueId}/${appName}/variables/response`, (topic, message) => {
-			console.log('[Figma] <<<< variables/response', topic, message.toString());
+			logger.log('[Figma] <<<< variables/response', topic, message.toString());
 			updateVariableTypes(JSON.parse(message.toString()) as Record<string, FigmaVariable>);
 		});
 	}, [subscribe, uniqueId, appName, updateVariableTypes]);

--- a/apps/electron-app/src/common/types.ts
+++ b/apps/electron-app/src/common/types.ts
@@ -1,3 +1,4 @@
+import { type Message } from '@microflow/hardware/src/utils/postMessageToElectronMain';
 import type { Edge, Node } from '@xyflow/react';
 
 // https://github.com/firmata/protocol/blob/master/protocol.md#supported-modes
@@ -64,11 +65,6 @@ export type FlowState = {
 	edges: Edge[];
 };
 
-export type UploadedCodeMessage = {
-	type: 'message';
-	nodeId: string;
-	action: string;
-	value?: unknown;
-};
+export type UploadedCodeMessage<T = unknown> = Message<T> & { type: 'message' };
 
 export type IpcResponse<T> = { success: true; data: T } | { success: false; error: string };

--- a/apps/electron-app/src/preload.ts
+++ b/apps/electron-app/src/preload.ts
@@ -2,6 +2,9 @@
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 import { IpcResponse } from './common/types';
+// import logger from 'electron-log/node';
+
+const logger = console;
 
 export type Channels =
 	| 'ipc-microcontroller'
@@ -19,7 +22,7 @@ const listeners = new Map<string, Listener>();
 export const electronHandler = {
 	ipcRenderer: {
 		send<Data>(channel: Channels, data?: Data) {
-			console.debug('[IPC] <send>', channel, data);
+			logger.debug('[IPC] <send>', channel, data);
 			console.time(`send ${channel}`);
 			ipcRenderer.send(channel, data);
 			console.timeEnd(`send ${channel}`);

--- a/apps/electron-app/src/render/components/IpcDeepLinkListener.tsx
+++ b/apps/electron-app/src/render/components/IpcDeepLinkListener.tsx
@@ -2,6 +2,7 @@ import { toast } from '@microflow/ui';
 import { useEffect } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { useCollaborationActions } from '../stores/yjs';
+import logger from 'electron-log/node';
 
 export function IpcDeepLinkListener() {
 	const { getNodes } = useReactFlow();
@@ -13,14 +14,14 @@ export function IpcDeepLinkListener() {
 			result => {
 				if (!result.success) return;
 
-				console.debug('[IpcDeepLinkListener] <ipc-deep-link>', result);
+				logger.debug('[DEEP-LINK] <ipc-deep-link>', result);
 
 				switch (result.data.type) {
 					case 'web':
 						toast.success('Microflow studio successfully linked!');
 						break;
 					case 'share':
-						console.debug('[DEEP-LINK] Joining session via deep link - clearing local content');
+						logger.debug('[DEEP-LINK] Joining session via deep link - clearing local content');
 						connect(String(result.data.tunnelUrl), { isJoining: true });
 						break;
 					case 'figma':
@@ -33,7 +34,7 @@ export function IpcDeepLinkListener() {
 						});
 						break;
 					default:
-						console.debug('no know deeplink action for', result.data.type);
+						logger.debug('[DEEP-LINK] no know deeplink action for', result.data.type);
 						break;
 				}
 			}

--- a/apps/electron-app/src/render/components/react-flow/nodes/Delay.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/Delay.tsx
@@ -18,7 +18,13 @@ export function Delay(props: Props) {
 function Value() {
 	const data = useNodeData<DelayData>();
 
-	return <IconWithValue icon='Snail' value={data.delay / 1000} suffix='s' />;
+	return (
+		<IconWithValue
+			icon='Snail'
+			value={`${data.forgetPrevious ? 'debounced ' : ''}${data.delay / 1000}`}
+			suffix='s'
+		/>
+	);
 }
 
 function Settings() {

--- a/apps/electron-app/src/render/components/react-flow/nodes/Gate.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/Gate.tsx
@@ -6,18 +6,14 @@ import { useNodeValue } from '../../../stores/node-data';
 import { uid } from '../../../../common/uuid';
 
 export function Gate(props: Props) {
-	function getOffset(index: number) {
-		return index - ((props.data.gate === 'not' ? 1 : 2) - 1) / 2;
-	}
-
 	return (
 		<NodeContainer {...props}>
 			<Value />
 			<Settings />
 			<Handle type='target' position={Position.Left} id={'check'} />
 			<Handle type='source' position={Position.Right} id='true' offset={-1} />
-			<Handle type='source' position={Position.Right} id='false' />
-			<Handle type='source' position={Position.Right} id='change' offset={1} />
+			<Handle type='source' position={Position.Right} id='change' />
+			<Handle type='source' position={Position.Right} id='false' offset={1} />
 		</NodeContainer>
 	);
 }
@@ -39,7 +35,7 @@ function Settings() {
 	const { render } = useNodeControls({
 		gate: {
 			value: data.gate,
-			options: ['not', 'and', 'nand', 'or', 'nor', 'xor', 'xnor'],
+			options: ['and', 'nand', 'or', 'nor', 'xor', 'xnor'],
 		},
 	});
 
@@ -60,20 +56,6 @@ Gate.defaultProps = {
 const DEFAULT_ICON_SIZE = 60;
 function GateIcon(props: { gate: GateData['gate']; size?: number; className?: string }) {
 	switch (props.gate) {
-		case 'not':
-			return (
-				<svg
-					className={props.className}
-					width={props.size ?? DEFAULT_ICON_SIZE}
-					height={props.size ?? DEFAULT_ICON_SIZE}
-					viewBox='0 0 24 24'
-					fill='none'
-					xmlns='http://www.w3.org/2000/svg'
-				>
-					<path d='M6 6L6 18L14 12L6 6Z' stroke='currentColor' strokeWidth='2' />
-					<circle cx='17' cy='12' r='2' stroke='currentColor' strokeWidth='2' />
-				</svg>
-			);
 		case 'and':
 			return (
 				<svg

--- a/apps/electron-app/src/render/components/react-flow/nodes/Interval.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/Interval.tsx
@@ -46,6 +46,7 @@ Interval.defaultProps = {
 		group: 'flow',
 		tags: ['event'],
 		label: 'Interval',
+		autoStart: true,
 		interval: 500,
 		description: 'Emit a signal at a regular interval',
 	} satisfies Props['data'],

--- a/apps/electron-app/src/render/components/react-flow/nodes/Monitor.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/Monitor.tsx
@@ -38,8 +38,14 @@ function Value() {
 
 	if (data.type === 'raw')
 		return (
-			<div className='text-xs text-gray-500 text-start grow p-4'>
-				{typeof value === 'string' ? value : <pre>{JSON.stringify(value, null, 2)}</pre>}
+			<div className='text-xs text-gray-500 text-start grow p-4 max-w-md'>
+				{typeof value === 'string' ? (
+					value.startsWith('{') ? (
+						<pre>{JSON.stringify(JSON.parse(value), null, 2)}</pre>
+					) : (
+						<div className='whitespace-pre-line'>{value}</div>
+					)
+				) : null}
 			</div>
 		);
 	return <LevaPanel store={store} fill={true} flat titleBar={false} />;

--- a/apps/electron-app/src/render/components/react-flow/nodes/Node.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/Node.tsx
@@ -1,5 +1,4 @@
 import {
-	Button,
 	Card,
 	CardAction,
 	CardContent,
@@ -31,6 +30,7 @@ import { useDebounceValue } from 'usehooks-ts';
 import { useFlowSync } from '../../../hooks/useFlowSync';
 import { usePins } from '../../../stores/board';
 import { pinDisplayValue } from '../../../../common/pin';
+import logger from 'electron-log/node';
 
 function NodeHeader(props: { error?: string }) {
 	const data = useNodeData();
@@ -110,7 +110,7 @@ export const useNodeControls = <
 
 	const updateNodeData = useCallback(
 		async (data: Record<string, unknown>) => {
-			console.debug('[useNodeControls] <updateNodeData>', data);
+			logger.debug('[NODE-CONTROLS] <updateNodeData>', data);
 			const node = getNode(id);
 			if (!node) return;
 
@@ -192,7 +192,7 @@ export const useNodeControls = <
 		// Prevent other effects from running
 		lastControlData.current = newData as typeof lastControlData.current;
 		set(newData as Parameters<typeof set>[0]);
-		console.debug('[useNodeControls] <useEffect>', lastControlData.current, { data, newData });
+		logger.debug('[NODE-CONTROLS] <useEffect>', lastControlData.current, { data, newData });
 		flowChanged();
 	}, [data, set, flowChanged]);
 

--- a/apps/electron-app/src/render/hooks/useSignalNodesAndEdges.ts
+++ b/apps/electron-app/src/render/hooks/useSignalNodesAndEdges.ts
@@ -16,24 +16,23 @@ export function useSignalNodesAndEdges() {
 
 			if (result.data.value instanceof Error) {
 				toast.error(result.data.value.message, {
-					description: `Error in node ${result.data.nodeId} with handle ${result.data.action}`,
+					description: `Error in node ${result.data.source} with handle ${result.data.action.toString()}`,
 					duration: Infinity,
 				});
 				return;
 			}
 
-			update(result.data.nodeId, result.data.value);
+			update(result.data.source, result.data.value);
 
-			// Find edges connected to the source node and handle
-			const connectedEdges = getEdges().filter(
-				({ source, sourceHandle }) =>
-					source === result.data.nodeId && sourceHandle === result.data.action
-			);
+			if (!result.data.target) return;
 
-			// Add signals to each connected edge
-			connectedEdges.forEach(edge => {
-				addSignal(edge.id);
+			const connectedEdges = getEdges().filter(({ source, target, sourceHandle }) => {
+				const isSource = source === result.data.source && sourceHandle === result.data.action;
+				const isTarget = target === result.data.target;
+				return isSource && isTarget;
 			});
+
+			connectedEdges.forEach(edge => addSignal(edge.id));
 		});
 	}, [getEdges, update, addSignal]);
 

--- a/apps/electron-app/src/render/stores/yjs.ts
+++ b/apps/electron-app/src/render/stores/yjs.ts
@@ -7,6 +7,7 @@ import { useShallow } from 'zustand/shallow';
 import { getLocalItem, setLocalItem } from '../../common/local-storage';
 import { Node, Edge } from '@xyflow/react';
 import { useAppStore, User } from './app';
+import logger from 'electron-log/node';
 
 export type CollaborationStatus =
 	| { type: 'disconnected' }
@@ -132,7 +133,7 @@ export const useYjsStore = create<YjsState>()((set, get) => {
 			const stateString = JSON.stringify(Array.from(state));
 			setLocalItem('yjs-state', stateString);
 		} catch (error) {
-			console.warn('[COLLABORATION] Failed to save state:', error);
+			logger.warn('[COLLABORATION] Failed to save state:', error);
 		}
 	};
 
@@ -144,7 +145,7 @@ export const useYjsStore = create<YjsState>()((set, get) => {
 			const uint8Array = new Uint8Array(JSON.parse(savedState));
 			YJS.applyUpdate(ydoc, uint8Array);
 		} catch (error) {
-			console.warn('[COLLABORATION] Failed to load saved state:', error);
+			logger.warn('[COLLABORATION] Failed to load saved state:', error);
 		}
 	};
 
@@ -322,7 +323,7 @@ export const useYjsStore = create<YjsState>()((set, get) => {
 				});
 
 				provider.on('peers', peers => {
-					console.debug('[COLLABORATION]', { peers });
+					logger.debug('[COLLABORATION]', { peers });
 					set({ peers: get().peers + peers.added.length - peers.removed.length });
 					updatePeerCursors();
 				});
@@ -332,7 +333,7 @@ export const useYjsStore = create<YjsState>()((set, get) => {
 				updatePeerCursors(); // Initial update
 				updateLocalUserData(useAppStore.getState().user); // Set initial local user data
 			} catch (error) {
-				console.error('[COLLABORATION] Failed to connect:', error);
+				logger.error('[COLLABORATION] Failed to connect:', error);
 				set({
 					collaborationStatus: {
 						type: 'error',

--- a/packages/hardware/src/components/BaseComponent.ts
+++ b/packages/hardware/src/components/BaseComponent.ts
@@ -39,7 +39,7 @@ export class BaseComponent<
 		this.id = data.id;
 
 		// Make sure we post the message when the value changes even though no one is listening to the event
-		super.on('change', () => this.postMessage('change'));
+		super.on('change', () => this.postMessage('change', this.id));
 	}
 
 	set data(data: BaseComponentData & Data) {
@@ -76,10 +76,11 @@ export class BaseComponent<
 		this.emit('change', value);
 	}
 
-	postMessage(action: string | symbol) {
+	postMessage(action: string | symbol, target: string) {
 		postMessageToElectronMain({
 			action,
-			nodeId: this.id,
+			source: this.id,
+			target,
 			value: this.value,
 		});
 	}

--- a/packages/hardware/src/components/Button.ts
+++ b/packages/hardware/src/components/Button.ts
@@ -1,18 +1,15 @@
 import JohnnyFive, { ButtonOption } from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { BaseComponentData, Hardware } from './BaseComponent';
 
 export type ButtonData = Omit<ButtonOption, 'board'>;
 export type ButtonValueType = boolean | number;
 
-export class Button extends BaseComponent<ButtonValueType, ButtonData, JohnnyFive.Button> {
+export class Button extends Hardware<ButtonValueType, ButtonData, JohnnyFive.Button> {
 	constructor(data: BaseComponentData & ButtonData) {
 		super(data, false);
-
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & ButtonData));
 	}
 
-	private createComponent(data: BaseComponentData & ButtonData) {
+	protected createComponent(data: BaseComponentData & ButtonData) {
 		this.component = new JohnnyFive.Button(data);
 		this.component.on('up', () => {
 			this.value = false;
@@ -25,5 +22,6 @@ export class Button extends BaseComponent<ButtonValueType, ButtonData, JohnnyFiv
 		this.component.on('hold', () => {
 			this.emit('hold', this.value);
 		});
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/Calculate.ts
+++ b/packages/hardware/src/components/Calculate.ts
@@ -1,5 +1,5 @@
 import { transformValueToNumber } from '../utils/transformUnknownValues';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { BaseComponentData, Code } from './BaseComponent';
 
 export type CalculateValueType = number;
 
@@ -7,7 +7,7 @@ export type CalculateData = {
 	function: 'add' | 'subtract' | 'multiply' | 'divide' | 'modulo' | keyof typeof Math;
 };
 
-export class Calculate extends BaseComponent<CalculateValueType, CalculateData> {
+export class Calculate extends Code<CalculateValueType, CalculateData> {
 	constructor(data: BaseComponentData & CalculateData) {
 		super(data, 0);
 	}

--- a/packages/hardware/src/components/Compare.ts
+++ b/packages/hardware/src/components/Compare.ts
@@ -1,5 +1,5 @@
 import { transformValueToBoolean } from '../utils/transformUnknownValues';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { BaseComponentData, Code } from './BaseComponent';
 import { COMPARE_SUB_VALIDATORS } from '../constants/Compare';
 
 type BooleanData = {
@@ -37,7 +37,7 @@ export type CompareData = BooleanData | TextData | NumberData | SingleNumberData
 
 export type CompateValueType = boolean;
 
-export class Compare extends BaseComponent<CompateValueType, CompareData> {
+export class Compare extends Code<CompateValueType, CompareData> {
 	constructor(data: BaseComponentData & CompareData) {
 		super(data, false);
 	}

--- a/packages/hardware/src/components/Constant.ts
+++ b/packages/hardware/src/components/Constant.ts
@@ -1,4 +1,4 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type ConstantValueType = number;
 
@@ -6,7 +6,7 @@ export type ConstantData = {
 	value: number;
 };
 
-export class Constant extends BaseComponent<ConstantValueType, ConstantData> {
+export class Constant extends Code<ConstantValueType, ConstantData> {
 	constructor(data: BaseComponentData & ConstantData) {
 		super(data, data.value);
 	}

--- a/packages/hardware/src/components/Counter.ts
+++ b/packages/hardware/src/components/Counter.ts
@@ -1,10 +1,10 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 import { transformValueToNumber } from '../utils/transformUnknownValues';
 
 export type CounterData = {};
 export type CounterValueType = number;
 
-export class Counter extends BaseComponent<CounterValueType, CounterData> {
+export class Counter extends Code<CounterValueType, CounterData> {
 	constructor(data: BaseComponentData & CounterData) {
 		super(data, 0);
 	}

--- a/packages/hardware/src/components/Delay.ts
+++ b/packages/hardware/src/components/Delay.ts
@@ -1,4 +1,4 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type DelayValueType = number;
 
@@ -7,7 +7,7 @@ export type DelayData = {
 	forgetPrevious: boolean;
 };
 
-export class Delay extends BaseComponent<DelayValueType, DelayData> {
+export class Delay extends Code<DelayValueType, DelayData> {
 	private lastTimeout: NodeJS.Timeout | null = null;
 
 	constructor(data: BaseComponentData & DelayData) {

--- a/packages/hardware/src/components/Figma.ts
+++ b/packages/hardware/src/components/Figma.ts
@@ -1,4 +1,4 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 import { RGBA } from '../types';
 import { transformValueToNumber, transformValueToBoolean } from '../utils/transformUnknownValues';
 
@@ -10,7 +10,7 @@ export type FigmaData = {
 };
 export type FigmaValueType = string | number | boolean | RGBA;
 
-export class Figma extends BaseComponent<FigmaValueType, FigmaData> {
+export class Figma extends Code<FigmaValueType, FigmaData> {
 	private readonly defaultRGBA = { r: 0, g: 0, b: 0, a: 1 };
 
 	constructor(data: BaseComponentData & FigmaData) {

--- a/packages/hardware/src/components/Gate.ts
+++ b/packages/hardware/src/components/Gate.ts
@@ -1,15 +1,15 @@
 import { transformValueToBoolean } from '../utils/transformUnknownValues';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type GateValueType = boolean;
 
-type GateType = 'or' | 'and' | 'xor' | 'not' | 'nor' | 'nand' | 'xnor';
+type GateType = 'or' | 'and' | 'xor' | 'nor' | 'nand' | 'xnor';
 
 export type GateData = {
 	gate: GateType;
 };
 
-export class Gate extends BaseComponent<GateValueType, GateData> {
+export class Gate extends Code<GateValueType, GateData> {
 	constructor(data: BaseComponentData & GateData) {
 		super(data, false);
 	}
@@ -25,9 +25,6 @@ export class Gate extends BaseComponent<GateValueType, GateData> {
 	private passesGate(inputs: boolean[]) {
 		const amountOfTrue = inputs.filter(Boolean).length;
 		switch (this.data.gate) {
-			case 'not':
-				if (amountOfTrue === inputs.length) return false;
-				return true;
 			case 'and':
 				return amountOfTrue === inputs.length;
 			case 'nand':

--- a/packages/hardware/src/components/Gate.ts
+++ b/packages/hardware/src/components/Gate.ts
@@ -26,7 +26,8 @@ export class Gate extends BaseComponent<GateValueType, GateData> {
 		const amountOfTrue = inputs.filter(Boolean).length;
 		switch (this.data.gate) {
 			case 'not':
-				return !amountOfTrue;
+				if (amountOfTrue === inputs.length) return false;
+				return true;
 			case 'and':
 				return amountOfTrue === inputs.length;
 			case 'nand':

--- a/packages/hardware/src/components/Interval.ts
+++ b/packages/hardware/src/components/Interval.ts
@@ -1,5 +1,5 @@
 import { MIN_INTERVAL_IN_MS } from '../constants/Interval';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type IntervalData = {
 	interval: number;
@@ -7,13 +7,13 @@ export type IntervalData = {
 };
 export type IntervalValueType = number;
 
-export class Interval extends BaseComponent<IntervalValueType, IntervalData> {
+export class Interval extends Code<IntervalValueType, IntervalData> {
 	private timeout: NodeJS.Timeout | null = null;
 
 	constructor(data: BaseComponentData & IntervalData) {
 		super(data, 0);
 
-		this.start();
+		if (data.autoStart) this.start();
 	}
 
 	start() {

--- a/packages/hardware/src/components/Led.ts
+++ b/packages/hardware/src/components/Led.ts
@@ -1,15 +1,12 @@
 import JohnnyFive, { LedOption } from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 
 export type LedData = Omit<LedOption, 'board'>;
 export type LedValueType = number;
 
-export class Led extends BaseComponent<LedValueType, LedData, JohnnyFive.Led> {
+export class Led extends Hardware<LedValueType, LedData, JohnnyFive.Led> {
 	constructor(data: BaseComponentData & LedData) {
 		super(data, 0);
-
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & LedData));
 	}
 
 	turnOn() {
@@ -32,7 +29,8 @@ export class Led extends BaseComponent<LedValueType, LedData, JohnnyFive.Led> {
 		this.value = value;
 	}
 
-	private createComponent(data: BaseComponentData & LedData) {
+	protected createComponent(data: BaseComponentData & LedData): JohnnyFive.Led {
 		this.component = new JohnnyFive.Led(data);
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/Matrix.ts
+++ b/packages/hardware/src/components/Matrix.ts
@@ -1,5 +1,5 @@
 import JohnnyFive from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { BaseComponentData, Hardware } from './BaseComponent';
 import { DEFAULT_MATRIX_START_SHAPE, type MatrixShape } from '../constants/Matrix';
 import { transformValueToNumber } from '../utils/transformUnknownValues';
 
@@ -13,7 +13,7 @@ export type MatrixData = Omit<
 };
 export type MatrixValueType = MatrixShape;
 
-export class Matrix extends BaseComponent<MatrixValueType, MatrixData, JohnnyFive.Led.Matrix> {
+export class Matrix extends Hardware<MatrixValueType, MatrixData, JohnnyFive.Led.Matrix> {
 	constructor(data: BaseComponentData & MatrixData) {
 		super(data, DEFAULT_MATRIX_START_SHAPE);
 
@@ -65,10 +65,11 @@ export class Matrix extends BaseComponent<MatrixValueType, MatrixData, JohnnyFiv
 		return Number(this.data.dims.split('x').map(Number)[1]);
 	}
 
-	private createComponent(data: BaseComponentData & MatrixData) {
+	protected createComponent(data: BaseComponentData & MatrixData) {
 		this.component = new JohnnyFive.Led.Matrix(data);
 
 		this.component.brightness(100);
 		this.component.off();
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/Monitor.ts
+++ b/packages/hardware/src/components/Monitor.ts
@@ -1,4 +1,4 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type DebugValueType = unknown;
 
@@ -7,7 +7,7 @@ export type MonitorData = {
 	fps: number;
 };
 
-export class Monitor extends BaseComponent<DebugValueType, MonitorData> {
+export class Monitor extends Code<DebugValueType, MonitorData> {
 	constructor(data: BaseComponentData & MonitorData) {
 		super(data, 0);
 	}

--- a/packages/hardware/src/components/Motion.ts
+++ b/packages/hardware/src/components/Motion.ts
@@ -1,6 +1,6 @@
 import JohnnyFive, { MotionOption } from 'johnny-five';
 import { Controller } from '../constants/Motion';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 
 export type MotionData = Omit<MotionOption, 'board'> & {
 	controller: Controller;
@@ -8,15 +8,12 @@ export type MotionData = Omit<MotionOption, 'board'> & {
 export type MotionValueType = boolean;
 export type { Controller } from '../constants/Motion';
 
-export class Motion extends BaseComponent<MotionValueType, MotionData, JohnnyFive.Motion> {
+export class Motion extends Hardware<MotionValueType, MotionData, JohnnyFive.Motion> {
 	constructor(data: BaseComponentData & MotionData) {
 		super(data, false);
-
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & MotionData));
 	}
 
-	private createComponent(data: BaseComponentData & MotionData) {
+	protected createComponent(data: BaseComponentData & MotionData) {
 		this.component = new JohnnyFive.Motion(data);
 
 		this.component.on('motionstart', () => {
@@ -36,5 +33,6 @@ export class Motion extends BaseComponent<MotionValueType, MotionData, JohnnyFiv
 			if (!isCalibrated) return;
 			this.value = detectedMotion;
 		});
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/Mqtt.ts
+++ b/packages/hardware/src/components/Mqtt.ts
@@ -1,11 +1,11 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type MqttDirection = 'publish' | 'subscribe';
 
 export type MqttData = { direction: MqttDirection; topic?: string };
 export type MqttValueType = string;
 
-export class Mqtt extends BaseComponent<MqttValueType, MqttData> {
+export class Mqtt extends Code<MqttValueType, MqttData> {
 	constructor(data: BaseComponentData & MqttData) {
 		super(data, '');
 	}

--- a/packages/hardware/src/components/Oscillator.ts
+++ b/packages/hardware/src/components/Oscillator.ts
@@ -1,4 +1,4 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 /**
  * Function generator is a very versatile way of doing things in mcus
  * it can be used to control timing as well as values. For example a
@@ -20,7 +20,7 @@ export type OscillatorData = {
 };
 export type OscillatorValueType = number;
 
-export class Oscillator extends BaseComponent<OscillatorValueType, OscillatorData> {
+export class Oscillator extends Code<OscillatorValueType, OscillatorData> {
 	// auto-calculated values when "period" is reset
 	private freq1 = 0;
 	private freq2 = 0;

--- a/packages/hardware/src/components/Piezo.ts
+++ b/packages/hardware/src/components/Piezo.ts
@@ -1,5 +1,5 @@
 import JohnnyFive, { PiezoOption, PiezoTune } from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 
 export type BuzzData = { type: 'buzz'; duration: number; frequency: number };
 export type Note = [string | null, number];
@@ -10,13 +10,11 @@ export type SongData = { type: 'song' } & PiezoTune & {
 export type PiezoData = PiezoOption & (BuzzData | SongData);
 export type PiezoValueType = boolean;
 
-export class Piezo extends BaseComponent<PiezoValueType, PiezoData, JohnnyFive.Piezo> {
+export class Piezo extends Hardware<PiezoValueType, PiezoData, JohnnyFive.Piezo> {
 	private timeout: NodeJS.Timeout | undefined;
 
 	constructor(data: BaseComponentData & PiezoData) {
 		super(data, false);
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & PiezoData));
 	}
 
 	buzz() {
@@ -63,7 +61,8 @@ export class Piezo extends BaseComponent<PiezoValueType, PiezoData, JohnnyFive.P
 		return this;
 	}
 
-	private createComponent(data: BaseComponentData & PiezoData) {
+	protected createComponent(data: BaseComponentData & PiezoData) {
 		this.component = new JohnnyFive.Piezo(data);
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/Proximity.ts
+++ b/packages/hardware/src/components/Proximity.ts
@@ -1,26 +1,20 @@
 import JohnnyFive, { ProximityOption } from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 
 export type ProximityData = Omit<ProximityOption, 'board'>;
 export type ProximityValueType = number;
 
-export class Proximity extends BaseComponent<
-	ProximityValueType,
-	ProximityData,
-	JohnnyFive.Proximity
-> {
+export class Proximity extends Hardware<ProximityValueType, ProximityData, JohnnyFive.Proximity> {
 	constructor(data: BaseComponentData & ProximityData) {
 		super(data, 0);
-
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & ProximityData));
 	}
 
-	private createComponent(data: BaseComponentData & ProximityData) {
+	protected createComponent(data: BaseComponentData & ProximityData) {
 		this.component = new JohnnyFive.Proximity(data);
 
 		this.component.on('data', data => {
 			this.value = data.cm;
 		});
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/RGB.ts
+++ b/packages/hardware/src/components/RGB.ts
@@ -1,19 +1,16 @@
 import JohnnyFive from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 import { RGBA } from '../types';
 
 export type RgbData = Omit<ConstructorParameters<typeof JohnnyFive.Led.RGB>[0], 'board'>;
 
 export type RgbValueType = RGBA;
 
-export class Rgb extends BaseComponent<RgbValueType, RgbData, JohnnyFive.Led.RGB> {
+export class Rgb extends Hardware<RgbValueType, RgbData, JohnnyFive.Led.RGB> {
 	private updateQueue: Promise<void> = Promise.resolve();
 
 	constructor(data: BaseComponentData & RgbData) {
 		super(data, { r: 0, g: 0, b: 0, a: 1 });
-
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & RgbData));
 	}
 
 	red(value: number) {
@@ -63,7 +60,8 @@ export class Rgb extends BaseComponent<RgbValueType, RgbData, JohnnyFive.Led.RGB
 		return `#${redHex}${greenHex}${blueHex}`;
 	}
 
-	private createComponent(data: BaseComponentData & RgbData) {
+	protected createComponent(data: BaseComponentData & RgbData) {
 		this.component = new JohnnyFive.Led.RGB(data);
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/RangeMap.ts
+++ b/packages/hardware/src/components/RangeMap.ts
@@ -1,4 +1,4 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type Range = { min: number; max: number };
 export type RangeMapData = {
@@ -7,7 +7,7 @@ export type RangeMapData = {
 };
 export type RangeMapValueType = [number, number];
 
-export class RangeMap extends BaseComponent<RangeMapValueType, RangeMapData> {
+export class RangeMap extends Code<RangeMapValueType, RangeMapData> {
 	constructor(data: BaseComponentData & RangeMapData) {
 		super(data, [0, 0]);
 	}

--- a/packages/hardware/src/components/Relay.ts
+++ b/packages/hardware/src/components/Relay.ts
@@ -1,16 +1,13 @@
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 
 import JohnnyFive, { RelayOption } from 'johnny-five';
 
 export type RelayValueType = boolean;
 export type RelayData = Omit<RelayOption, 'board'>;
 
-export class Relay extends BaseComponent<RelayValueType, RelayData, JohnnyFive.Relay> {
+export class Relay extends Hardware<RelayValueType, RelayData, JohnnyFive.Relay> {
 	constructor(data: BaseComponentData & RelayData) {
 		super(data, false);
-
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & RelayData));
 	}
 
 	open() {
@@ -28,7 +25,8 @@ export class Relay extends BaseComponent<RelayValueType, RelayData, JohnnyFive.R
 		this.value = !this.value;
 	}
 
-	private createComponent(data: BaseComponentData & RelayData) {
+	protected createComponent(data: BaseComponentData & RelayData) {
 		this.component = new JohnnyFive.Relay(data);
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/Sensor.ts
+++ b/packages/hardware/src/components/Sensor.ts
@@ -1,22 +1,19 @@
 import JohnnyFive, { SensorOption } from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 
 export type SensorData = Omit<SensorOption, 'board'>;
 export type SensorValueType = number;
 
-export class Sensor extends BaseComponent<SensorValueType, SensorData, JohnnyFive.Sensor> {
+export class Sensor extends Hardware<SensorValueType, SensorData, JohnnyFive.Sensor> {
 	constructor(data: BaseComponentData & SensorData) {
 		super(data, 0);
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & SensorData));
 	}
 
-	private createComponent(data: BaseComponentData & SensorData) {
+	protected createComponent(data: BaseComponentData & SensorData) {
 		this.component = new JohnnyFive.Sensor(data);
-		this.value = Number(this.component.raw);
-
 		this.component.on('change', () => {
-			this.value = Number(this.component?.raw ?? 0);
+			this.value = Number(this.component.raw);
 		});
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/Servo.ts
+++ b/packages/hardware/src/components/Servo.ts
@@ -1,17 +1,14 @@
 import JohnnyFive, { ServoGeneralOption } from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 
 export type ServoData = Omit<ServoGeneralOption, 'board' | 'range'> & {
 	range: { min: number; max: number };
 };
 export type ServoValueType = number;
 
-export class Servo extends BaseComponent<ServoValueType, ServoData, JohnnyFive.Servo> {
+export class Servo extends Hardware<ServoValueType, ServoData, JohnnyFive.Servo> {
 	constructor(data: BaseComponentData & ServoData) {
 		super(data, 0);
-
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & ServoData));
 	}
 
 	min() {
@@ -52,10 +49,11 @@ export class Servo extends BaseComponent<ServoValueType, ServoData, JohnnyFive.S
 		this.value = this.component?.value ?? 0;
 	}
 
-	private createComponent(data: BaseComponentData & ServoData) {
+	protected createComponent(data: BaseComponentData & ServoData) {
 		this.component = new JohnnyFive.Servo({
 			...data,
 			range: [data.range.min, data.range.max],
 		});
+		return this.component;
 	}
 }

--- a/packages/hardware/src/components/Smooth.ts
+++ b/packages/hardware/src/components/Smooth.ts
@@ -1,5 +1,5 @@
 import { transformValueToNumber } from '../utils/transformUnknownValues';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type SmoothAverage = {
 	type: 'smooth';
@@ -15,7 +15,7 @@ export type SmoothData = SmoothAverage | MovingAverage;
 
 export type SmoothValueType = number;
 
-export class Smooth extends BaseComponent<SmoothValueType, SmoothData> {
+export class Smooth extends Code<SmoothValueType, SmoothData> {
 	private history: number[] = [];
 
 	constructor(data: BaseComponentData & SmoothData) {

--- a/packages/hardware/src/components/Switch.ts
+++ b/packages/hardware/src/components/Switch.ts
@@ -1,18 +1,15 @@
 import JohnnyFive, { SwitchOption } from 'johnny-five';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Hardware, BaseComponentData } from './BaseComponent';
 
 export type SwitchValueType = boolean;
 export type SwitchData = Omit<SwitchOption, 'board'>;
 
-export class Switch extends BaseComponent<SwitchValueType, SwitchData, JohnnyFive.Switch> {
+export class Switch extends Hardware<SwitchValueType, SwitchData, JohnnyFive.Switch> {
 	constructor(data: BaseComponentData & SwitchData) {
 		super(data, false);
-
-		this.createComponent(data);
-		this.on('new-data', data => this.createComponent(data as BaseComponentData & SwitchData));
 	}
 
-	private createComponent(data: BaseComponentData & SwitchData) {
+	protected createComponent(data: BaseComponentData & SwitchData) {
 		this.component = new JohnnyFive.Switch(data);
 		this.component.on('open', () => {
 			this.value = true;
@@ -23,6 +20,7 @@ export class Switch extends BaseComponent<SwitchValueType, SwitchData, JohnnyFiv
 			this.value = false;
 			this.emit('close', this.value);
 		});
+		return this.component;
 	}
 }
 

--- a/packages/hardware/src/components/Trigger.ts
+++ b/packages/hardware/src/components/Trigger.ts
@@ -1,5 +1,5 @@
 import { transformValueToNumber } from '../utils/transformUnknownValues';
-import { BaseComponent, BaseComponentData } from './BaseComponent';
+import { Code, BaseComponentData } from './BaseComponent';
 
 export type TriggerData = {
 	relative?: boolean;
@@ -15,7 +15,7 @@ type ValueWithTimestamp = {
 	timestamp: number;
 };
 
-export class Trigger extends BaseComponent<TriggerValueType, TriggerData> {
+export class Trigger extends Code<TriggerValueType, TriggerData> {
 	private history: ValueWithTimestamp[] = [];
 
 	constructor(data: BaseComponentData & TriggerData) {

--- a/packages/hardware/src/utils/postMessageToElectronMain.ts
+++ b/packages/hardware/src/utils/postMessageToElectronMain.ts
@@ -1,16 +1,8 @@
-import log from 'electron-log/node';
-
 export type Message<T> = {
-	/** The id of the source component */
 	source: string;
-	/**
-	 * The id of the target component
-	 * */
-	target: string;
-	/** The action to perform */
-	action: string | symbol;
+	sourceHandle: string;
+	edgeId?: string;
 	value: T;
-	error?: string;
 };
 
 // Poor mans electron parent port

--- a/packages/hardware/src/utils/postMessageToElectronMain.ts
+++ b/packages/hardware/src/utils/postMessageToElectronMain.ts
@@ -1,7 +1,13 @@
 import log from 'electron-log/node';
 
-type Message<T> = {
-	nodeId: string;
+export type Message<T> = {
+	/** The id of the source component */
+	source: string;
+	/**
+	 * The id of the target component
+	 * */
+	target: string;
+	/** The action to perform */
 	action: string | symbol;
 	value: T;
 	error?: string;


### PR DESCRIPTION
This pull request refactors the macOS code-signing and provisioning steps in the GitHub Actions workflow for building the Electron app. The main goal is to simplify and modernize the workflow by leveraging official GitHub Actions and removing manual scripting. This improves maintainability and reliability of the macOS build process.

**Workflow improvements (macOS):**
* Replaced manual certificate import and keychain management with the official `apple-actions/import-codesign-certs@v3` GitHub Action, using new secret names for certificate and password.
* Removed manual provisioning profile installation and replaced it with a streamlined Python setup step for macOS, ensuring required tools are installed via `pip install setuptools`.
* Eliminated manual cleanup of keychain and provisioning profile, relying on the new action's built-in management.

**Configuration updates:**
* Commented out the `identity` field in the `osxSign` configuration in `forge.config.js`, possibly to defer to the workflow's certificate management.