### PR TITLE
chore: simplyfy `YJS` handling

### DIFF
--- a/apps/electron-app/src/render/components/IpcDeepLinkListener.tsx
+++ b/apps/electron-app/src/render/components/IpcDeepLinkListener.tsx
@@ -2,7 +2,7 @@ import { toast } from '@microflow/ui';
 import { useEffect } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { useCollaborationActions } from '../stores/yjs';
-import logger from 'electron-log/node';
+import logger from 'electron-log/renderer';
 
 export function IpcDeepLinkListener() {
 	const { getNodes } = useReactFlow();

--- a/apps/electron-app/src/render/components/react-flow/nodes/Node.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/Node.tsx
@@ -30,7 +30,7 @@ import { useDebounceValue } from 'usehooks-ts';
 import { useFlowSync } from '../../../hooks/useFlowSync';
 import { usePins } from '../../../stores/board';
 import { pinDisplayValue } from '../../../../common/pin';
-import logger from 'electron-log/node';
+import logger from 'electron-log/renderer';
 
 function NodeHeader(props: { error?: string }) {
 	const data = useNodeData();


### PR DESCRIPTION
This pull request makes several improvements to the Electron app’s collaborative flow state management, focusing on more efficient syncing, better local state preservation, and code clarity. The main changes involve refactoring how updates are handled between local React Flow state and the YJS collaboration backend, optimizing sync logic to update only what’s changed, and ensuring local selection state is preserved during remote updates. Additionally, all logger imports have been updated for compatibility with the renderer process.

**Collaboration and state sync improvements:**

* Refactored the YJS update listener in `react-flow.ts` to preserve local selection state for nodes and edges during remote syncs, ensuring that user selections are not overwritten by collaborative updates.
* Improved deduplication logic for nodes and edges during initialization in `react-flow.ts` to prevent React key conflicts and added warnings for duplicates.
* Optimized sync logic in `yjs.ts` for nodes and edges: now only changed items are updated or deleted in YJS, reducing unnecessary operations and improving performance.

**Sync and update handling:**

* Refactored sync from local React Flow state to YJS to batch rapid changes with a debounce, and ensured all edges are set to type `'animated'` unless otherwise specified. Local state is updated immediately, while YJS sync is debounced for efficiency.
* Changed YJS transaction update handling to use the `afterTransaction` event, allowing more precise detection of changes to nodes and edges and preventing feedback loops by ignoring local-origin transactions.

**Logger compatibility:**

* Updated all logger imports from `'electron-log/node'` to `'electron-log/renderer'` in the renderer process files for correct logging context. [[1]](diffhunk://#diff-08e623226f110ebafb1dfec2540655a6f03eb0e532eed5a180947361c708ab5dL5-R5) [[2]](diffhunk://#diff-da8d36424d3595653ada2bd4b0db7919c3111806119660f0fbeb9e4964209a81L33-R33) [[3]](diffhunk://#diff-5f766a7b6b073c7dc96a216eb65217a2559e87a7631ce8f0ed94f8e1480bfa5fL10-R10)