### PR TITLE
feat(YJS): simplify the store and sync handling

### DIFF
--- a/apps/electron-app/src/main/window.ts
+++ b/apps/electron-app/src/main/window.ts
@@ -41,7 +41,9 @@ export function handleSecondInstance(commandLine: string[]) {
 	}
 
 	recreateWindowWhenNeeded().then(() => {
-		handleDeepLink(mainWindow!, commandLine.pop()?.slice(0, -1) ?? '');
+		const deepLink = commandLine.find(arg => arg.startsWith('microflow-studio://'));
+		if (!deepLink) return;
+		handleDeepLink(mainWindow!, deepLink);
 	});
 }
 

--- a/apps/electron-app/src/render/components/IpcMenuListener.tsx
+++ b/apps/electron-app/src/render/components/IpcMenuListener.tsx
@@ -10,8 +10,6 @@ import {
 	useSelectedNodes,
 } from '../stores/react-flow';
 import { useCollaborationActions } from '../stores/yjs';
-import { MqttSettingsForm } from './forms/MqttSettingsForm';
-import { AdvancedSettingsForm } from './forms/AdvancedSettingsForm';
 import { useAppStore } from '../stores/app';
 import { useNewNodeStore } from '../stores/new-node';
 import { useShallow } from 'zustand/shallow';

--- a/apps/electron-app/src/render/providers/NewNodeProvider.tsx
+++ b/apps/electron-app/src/render/providers/NewNodeProvider.tsx
@@ -96,21 +96,15 @@ export function NewNodeCommandDialog() {
 				const [label, description] = value.split('|');
 
 				// If no search term, return 0 (not relevant)
-				if (!search || search.trim() === '') {
-					return 0;
-				}
+				if (!search || search.trim() === '') return 0;
 
 				const searchLower = search.toLowerCase().trim();
 
 				// Priority 1: Label match (highest priority)
-				if (label.toLowerCase().includes(searchLower)) {
-					return 1;
-				}
+				if (label.toLowerCase().includes(searchLower)) return 1;
 
 				// Priority 2: Description match
-				if (description && description.toLowerCase().includes(searchLower)) {
-					return 0.8;
-				}
+				if (description.toLowerCase().includes(searchLower)) return 0.8;
 
 				// Priority 3: Keywords match
 				if (keywords && keywords.some(keyword => keyword.toLowerCase().includes(searchLower))) {


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Electron app's collaborative flow editor. The main changes focus on streamlining state synchronization, refining selection logic, and improving the initialization flow for new users.

### Collaboration and state synchronization

* The debounce timeout for syncing local changes to YJS was standardized to 250ms, and the debounce logic was simplified for clarity and reliability. Edge animation type is now only set when connecting, not on every sync. [[1]](diffhunk://#diff-417b5efd4c252fe1c9eee60f39ad1327f80bf70a06754f9d34ba2f06374443fdR29-R36) [[2]](diffhunk://#diff-417b5efd4c252fe1c9eee60f39ad1327f80bf70a06754f9d34ba2f06374443fdL94-R104) [[3]](diffhunk://#diff-417b5efd4c252fe1c9eee60f39ad1327f80bf70a06754f9d34ba2f06374443fdL119-R124)
* The logic for initializing introduction nodes and edges was simplified: introduction data is now imported statically, and the initialization check no longer redundantly verifies node existence. The `has-seen-introduction` flag is set immediately after initialization. [[1]](diffhunk://#diff-5f766a7b6b073c7dc96a216eb65217a2559e87a7631ce8f0ed94f8e1480bfa5fR11) [[2]](diffhunk://#diff-5f766a7b6b073c7dc96a216eb65217a2559e87a7631ce8f0ed94f8e1480bfa5fL260-R268)

### Selection and filtering logic

* Selection and filtering hooks (`useSelectedNodes`, `useSelectedEdges`, `useNonInternalNodes`) were rewritten for improved readability and correctness, using destructuring and explicit property checks.

### Deep link handling

* The deep link handler was updated to robustly extract the correct argument from the command line, preventing accidental truncation and ensuring only valid deep links are processed.

### Code style and minor refactoring

* Minor code style updates were made for consistency, such as simplifying conditional returns and removing unused imports. [[1]](diffhunk://#diff-258d98bca7737c588f1a9ac3266bcebcefa365ae8e90f91fd84f8d7337521c69L99-R107) [[2]](diffhunk://#diff-c5f4ab9e1ad04b4b56fd0dc99cbdfd86ffb0cd62edba5ad705ae9350f1707e19L13-L14) [[3]](diffhunk://#diff-5f766a7b6b073c7dc96a216eb65217a2559e87a7631ce8f0ed94f8e1480bfa5fL238-R239)