### PR TITLE
fix(RangeMap): disable joystick

### DIFF
--- a/apps/electron-app/src/render/components/react-flow/nodes/RangeMap.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/RangeMap.tsx
@@ -52,8 +52,8 @@ function Value() {
 function Settings() {
 	const data = useNodeData<RangeMapData>();
 	const { render } = useNodeControls({
-		from: { value: data.from, min: 0, max: 1023, step: 1 },
-		to: { value: data.to, min: 0, max: 1023, step: 1 },
+		from: { value: data.from, step: 1, joystick: false },
+		to: { value: data.to, step: 1, joystick: false },
 	});
 
 	return <>{render()}</>;


### PR DESCRIPTION
This pull request makes a minor update to the settings for the `RangeMap` node in the Electron app. The change simplifies the configuration of the `from` and `to` controls by removing the `min` and `max` properties and explicitly disabling joystick support.

* Removed `min` and `max` properties from the `from` and `to` controls, and added `joystick: false` to both, in `RangeMap.tsx`.