### PR TITLE
fix(Piezo): set proper data for buzz / song based on type

### DIFF
--- a/apps/electron-app/src/render/components/react-flow/nodes/piezo/Piezo.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/piezo/Piezo.tsx
@@ -54,7 +54,15 @@ function Settings() {
 				options: ['buzz', 'song'],
 				value: data.type,
 				transient: false,
-				onChange: event => deleteHandles(event === 'song' ? ['buzz'] : ['play']),
+				onChange: event => {
+					deleteHandles(event === 'song' ? ['buzz'] : ['play']);
+					setNodeData({
+						...data,
+						type: event,
+						tempo: event === 'song' ? 120 : undefined,
+						duration: event === 'buzz' ? 500 : undefined,
+					});
+				},
 			},
 			buzz: folder(
 				{
@@ -62,20 +70,13 @@ function Settings() {
 						min: 100,
 						max: 2500,
 						step: 100,
-						value: (data as BuzzData).duration!,
+						value: (data as BuzzData).duration ?? 500,
 						render: get => get('type') === 'buzz',
 					},
 					frequency: {
 						options: Object.fromEntries(NOTES_AND_FREQUENCIES.entries()),
 						value: (data as BuzzData).frequency!,
 						render: get => get('type') === 'buzz',
-					},
-					tempo: {
-						min: 40,
-						max: 240,
-						step: 10,
-						value: (data as SongData).tempo!,
-						render: get => get('type') === 'song',
 					},
 				},
 				{
@@ -84,6 +85,12 @@ function Settings() {
 			),
 			song: folder(
 				{
+					tempo: {
+						min: 40,
+						max: 240,
+						step: 10,
+						value: (data as SongData).tempo ?? 120,
+					},
 					'edit song': button(e => setEditorOpened(true)),
 				},
 				{
@@ -106,6 +113,7 @@ function Settings() {
 					}}
 					onSave={data => {
 						data.song = data.song;
+						console.log('data', data);
 						setNodeData(data);
 						setEditorOpened(false);
 					}}

--- a/apps/electron-app/src/render/components/react-flow/nodes/piezo/Piezo.tsx
+++ b/apps/electron-app/src/render/components/react-flow/nodes/piezo/Piezo.tsx
@@ -113,7 +113,6 @@ function Settings() {
 					}}
 					onSave={data => {
 						data.song = data.song;
-						console.log('data', data);
 						setNodeData(data);
 						setEditorOpened(false);
 					}}


### PR DESCRIPTION
This pull request updates the Piezo node settings UI to improve the handling of the `type` selection and ensure correct default values for `tempo` and `duration`. The main changes involve refactoring how the node's data is updated when switching between "buzz" and "song" types, and reorganizing the controls for these types to be more intuitive.

**Improvements to type switching and default values:**

* The `onChange` handler for the `type` field now updates the node data with appropriate default values for `tempo` (120 for "song") and `duration` (500 for "buzz") when switching types, ensuring the UI and data stay in sync.

**Refactoring of settings controls:**

* Moved the `tempo` control from the "buzz" folder to the "song" folder, so it only appears when editing a song, and set its default value to 120 if not already defined.
* Updated the default value logic for `duration` in the "buzz" folder to use 500 if not already set, improving robustness.