### PR TITLE
chore: use yarn in nixpacks

### DIFF
--- a/apps/signaling/nixpacks.toml
+++ b/apps/signaling/nixpacks.toml
@@ -2,13 +2,13 @@
 nixPkgs = ["nodejs_20"]
 
 [phases.install]
-cmds = ["npm ci"]
+cmds = ["corepack enable", "yarn workspaces focus microflow-signaling"]
 
 [phases.build]
-cmds = ["npm run build"]
+cmds = ["yarn workspace microflow-signaling build"]
 
 [start]
-cmd = "node dist/index.js"
+cmd = "node apps/signaling/dist/index.js"
 
 [variables]
 PORT = "4444"


### PR DESCRIPTION
This pull request updates the deployment configuration for the `microflow-signaling` app, switching the install and build processes from npm to Yarn workspaces and correcting the start command to reference the correct output file.

**Deployment configuration updates:**

* Changed the install phase to enable Corepack and use `yarn workspaces focus` for `microflow-signaling` instead of `npm ci` (`apps/signaling/nixpacks.toml`).
* Updated the build phase to use `yarn workspace microflow-signaling build` instead of `npm run build` (`apps/signaling/nixpacks.toml`).
* Fixed the start command to run the built file from `apps/signaling/dist/index.js` instead of `dist/index.js` (`apps/signaling/nixpacks.toml`).