### PR TITLE
fix(yarn): use `3.8.7`

### DIFF
--- a/apps/signaling/nixpacks.toml
+++ b/apps/signaling/nixpacks.toml
@@ -2,7 +2,7 @@
 nixPkgs = ["nodejs_20"]
 
 [phases.install]
-cmds = ["corepack enable", "yarn workspaces focus microflow-signaling"]
+cmds = ["corepack enable", "corepack prepare yarn@3.8.7 --activate", "yarn workspaces focus microflow-signaling"]
 
 [phases.build]
 cmds = ["yarn workspace microflow-signaling build"]


### PR DESCRIPTION
This pull request updates the installation process for the `microflow-signaling` app to ensure a specific version of Yarn is used during setup.

Dependency management:

* Updated the install phase in `apps/signaling/nixpacks.toml` to explicitly activate Yarn version 3.8.7 using `corepack prepare`, ensuring consistent dependency management across environments.