### PR TITLE
chore: install workspace-tools

### DIFF
--- a/apps/signaling/nixpacks.toml
+++ b/apps/signaling/nixpacks.toml
@@ -2,7 +2,7 @@
 nixPkgs = ["nodejs_20"]
 
 [phases.install]
-cmds = ["corepack enable", "corepack prepare yarn@3.8.7 --activate", "yarn workspaces focus microflow-signaling"]
+cmds = ["corepack enable", "corepack prepare yarn@3.8.7 --activate", "yarn plugin import workspace-tools", "yarn workspaces focus microflow-signaling"]
 
 [phases.build]
 cmds = ["yarn workspace microflow-signaling build"]


### PR DESCRIPTION
This pull request makes a small update to the `apps/signaling/nixpacks.toml` file to improve the Yarn workspace setup during the install phase.

* Added the `workspace-tools` plugin to Yarn during the install phase to enhance workspace management.