### PR TITLE
fix: test board ts error

### DIFF
--- a/packages/hardware/test.ts
+++ b/packages/hardware/test.ts
@@ -11,6 +11,7 @@ board.on('ready', () => {
 	const strip = new pixel.Strip({
 		data: 12, // LED data pin
 		length: 24, // number of LEDs
+		// @ts-ignore board errpr
 		board: board,
 		controller: 'FIRMATA', // Use Firmata-controlled Arduino
 		skip_firmware_check: true,


### PR DESCRIPTION
This pull request introduces a minor change to the `packages/hardware/test.ts` file. The change adds a TypeScript ignore directive to suppress a type error related to the `board` parameter when initializing the `pixel.Strip` object.