### PR TITLE
fix: sections for docs

### DIFF
--- a/apps/nextjs-app/lib/sections.ts
+++ b/apps/nextjs-app/lib/sections.ts
@@ -61,9 +61,7 @@ export type Section = H2Node['attributes'] & {
 	children: Array<Subsection>;
 };
 
-export function collectSections(nodes: Array<Node>, slugify = slugifyWithCounter()) {
-	let sections: Array<Section> = [];
-
+export function collectSections(nodes: Array<Node>, slugify = slugifyWithCounter(), sections: Array<Section> = []) {
 	for (let node of nodes) {
 		if (isH2Node(node) || isH3Node(node)) {
 			let title = getNodeText(node);
@@ -84,7 +82,7 @@ export function collectSections(nodes: Array<Node>, slugify = slugifyWithCounter
 			}
 		}
 
-		sections.push(...collectSections(node.children ?? [], slugify));
+		collectSections(node.children ?? [], slugify, sections);
 	}
 
 	return sections;


### PR DESCRIPTION
This pull request updates the `collectSections` function in `apps/nextjs-app/lib/sections.ts` to improve how sections are accumulated during recursion. Instead of creating a new array on each recursive call, the function now accepts an optional `sections` parameter and accumulates results in-place, which is more efficient and avoids unnecessary array allocations.

**Refactoring for efficiency and correctness:**

* Modified `collectSections` to take an optional `sections` array parameter, allowing in-place accumulation of sections during recursion, rather than creating and merging new arrays at each step.
* Updated recursive calls within `collectSections` to pass the existing `sections` array, ensuring all discovered sections are collected in the same array.